### PR TITLE
make it easy to remove rules from the "recommended" config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-no-restricted-syntax",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "keywords": [
     "eslint"
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,14 @@ const require = createRequire(import.meta.url);
 type WithLoc = { loc: TSESTree.SourceLocation };
 type RuleConfig<T extends WithLoc> = {
   /**
-   * A URL for more information
-   */
-  docUrl?: string;
-  /**
    * The level to use for the rule in the generated "recommended" config
    * @default 'error'
    */
-  level?: 'error' | 'warn';
+  defaultLevel?: 'error' | 'off' | 'warn';
+  /**
+   * A URL for more information
+   */
+  docUrl?: string;
   /**
    * The message to display when reporting the error. You may define
    * placeholders in the message and use `messageData` to fill in the data for
@@ -121,10 +121,12 @@ export function createNoRestrictedSyntaxRules<T extends WithLoc>(
           // assigned below to maintain plugin referential equality
         },
         rules: Object.fromEntries(
-          rules.map(config => [
-            `${pluginPrefix}/${config.name}`,
-            config.level ?? 'error',
-          ]),
+          rules
+            .filter(config => config.defaultLevel !== 'off')
+            .map(config => [
+              `${pluginPrefix}/${config.name}`,
+              config.defaultLevel ?? 'error',
+            ]),
         ),
       },
     },

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -15,6 +15,7 @@ describe('index', () => {
         selector: 'Identifier[name = "foo"]',
       },
       {
+        defaultLevel: 'warn',
         message: 'errors on the string "bar"',
         name: 'test2',
         selector: [
@@ -23,6 +24,7 @@ describe('index', () => {
         ],
       },
       {
+        defaultLevel: 'off',
         message: 'this message has a placeholder ->{{placeholder}}<-',
         messageData: (node: TSESTree.Node, sourceCode) => {
           if (node.parent?.type === AST_NODE_TYPES.VariableDeclarator) {
@@ -43,7 +45,7 @@ describe('index', () => {
   it('generates a flat config', () => {
     const plugin = createPlugin();
 
-    expect(plugin.configs).toMatchObject({
+    expect(plugin.configs).toEqual({
       recommended: {
         name: 'no-restricted-syntax/recommended',
         plugins: {
@@ -51,7 +53,7 @@ describe('index', () => {
         },
         rules: {
           'no-restricted-syntax/test1': 'error',
-          'no-restricted-syntax/test2': 'error',
+          'no-restricted-syntax/test2': 'warn',
         },
       },
     });
@@ -71,7 +73,14 @@ describe('index', () => {
     `;
 
     const linter = new Linter({ configType: 'flat' });
-    const result = linter.verify(code, plugin.configs.recommended);
+    const result = linter.verify(code, [
+      plugin.configs.recommended,
+      {
+        rules: {
+          'no-restricted-syntax/test3': 'error',
+        },
+      },
+    ]);
 
     expect(result).toMatchInlineSnapshot(`
       [
@@ -106,7 +115,7 @@ describe('index', () => {
           "messageId": "report",
           "nodeType": null,
           "ruleId": "no-restricted-syntax/test2",
-          "severity": 2,
+          "severity": 1,
         },
         {
           "column": 17,
@@ -117,7 +126,7 @@ describe('index', () => {
           "messageId": "report",
           "nodeType": null,
           "ruleId": "no-restricted-syntax/test2",
-          "severity": 2,
+          "severity": 1,
         },
         {
           "column": 17,
@@ -128,7 +137,7 @@ describe('index', () => {
           "messageId": "report",
           "nodeType": null,
           "ruleId": "no-restricted-syntax/test2",
-          "severity": 2,
+          "severity": 1,
         },
       ]
     `);


### PR DESCRIPTION

Summary:

Allow setting `defaultLevel: 'off'` to exclude a rule from the generated `recommended` config.
This makes it easier to add selectors which should only be turned on in  a subset of the codebase because you no longer need to disable it in the base config.

Test Plan:

```
pnpm run ci
```
